### PR TITLE
Update AutoStart of the Sample Plugins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,17 +38,27 @@ dependencies = [
 
 [[package]]
 name = "async-global-executor"
-version = "2.1.0"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd8b508d585e01084059b60f06ade4cb7415cd2e4084b71dd1cb44e7d3fb9880"
+checksum = "c290043c9a95b05d45e952fb6383c67bcb61471f60cfa21e890dba6654234f43"
 dependencies = [
  "async-channel",
  "async-executor",
  "async-io",
- "async-lock",
+ "async-mutex",
  "blocking",
  "futures-lite",
+ "num_cpus",
  "once_cell",
+]
+
+[[package]]
+name = "async-mutex"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479db852db25d9dbf6204e6cb6253698f175c15726470f78af0d918e99d6156e"
+dependencies = [
+ "event-listener",
 ]
 
 [[package]]

--- a/examples/calculator/calculator.json
+++ b/examples/calculator/calculator.json
@@ -2,5 +2,5 @@
  "locator":"libWPEFrameworkRustAdapter.so",
  "classname":"RustAdapter",
  "callsign":"calculator",
- "autostart":true
+ "autostart":false
 }

--- a/examples/hello_world/SampleRustPlugin.json
+++ b/examples/hello_world/SampleRustPlugin.json
@@ -2,7 +2,7 @@
  "locator":"libWPEFrameworkRustAdapter.so",
  "classname":"RustAdapter",
  "callsign":"hello_world",
- "autostart":true,
+ "autostart":false,
  "configuration": {
   "outofprocess": false,
   "address": "127.0.0.1",

--- a/examples/stateful_async/StatefulRustPlugin.json
+++ b/examples/stateful_async/StatefulRustPlugin.json
@@ -2,7 +2,7 @@
   "locator": "libWPEFrameworkRustAdapter.so",
   "classname": "RustAdapter",
   "callsign": "stateful_async",
-  "autostart": true,
+  "autostart": false,
   "configuration": {
     "outofprocess": false,
     "address": "127.0.0.1",


### PR DESCRIPTION
There are two changes into this review,
1. The autostart for this sample plugins are set to FALSE. Developers can activate when needed and when they test something.
2. async-global-executor of `2.0.4` is good enough for the sample program and doesn't require `2.1.0`.  This change is need because, RDK uses `rust-1.58.0` whereas to compile with `2.1.0`, we need `rust-1.59.0`