### PR TITLE
Updated the supported methods of Calculator

### DIFF
--- a/examples/calculator/calc_client.js
+++ b/examples/calculator/calc_client.js
@@ -22,7 +22,7 @@ function send_message() {
   let req = {};
   req.jsonrpc = "2.0"
   req.id = 5;
-  req.method = "calculator.add";
+  req.method = "add";
   req.params = [2, 2]
 
   const s = JSON.stringify(req);

--- a/examples/calculator/calculator.json
+++ b/examples/calculator/calculator.json
@@ -1,6 +1,12 @@
 {
- "locator":"libWPEFrameworkRustAdapter.so",
- "classname":"RustAdapter",
- "callsign":"calculator",
- "autostart":false
+    "locator":"libWPEFrameworkRustAdapter.so",
+    "classname":"RustAdapter",
+    "callsign":"calculator",
+    "autostart":false,
+    "configuration": {
+        "outofprocess": false,
+        "address": "127.0.0.1",
+        "port": 55556,
+        "autoexec": true
+    }
 }

--- a/examples/calculator/src/lib.rs
+++ b/examples/calculator/src/lib.rs
@@ -22,8 +22,8 @@ impl Calculator {
   fn dispatch_request(&mut self, req: json::JsonValue, ctx: thunder_rs::RequestContext) {
     if let Some(method) = req["method"].as_str() {
       match method {
-        "calculator.add" => { self.add(req, ctx); }
-        "calculator.mul" => { self.mul(req, ctx); }
+        "add" => { self.add(req, ctx); }
+        "mul" => { self.mul(req, ctx); }
         _ => {
           println!("method {} not handled here", method);
         }


### PR DESCRIPTION
- Updated the supported methods of Calculator.
- Updated the `calc_client.js` file
-- The `.js` establishes `WS` connection to calculator service; so, it does not have to say `calculator.add`
-- Thunder on the otherhand when request was sent as `calculator.add`, it identifies `RustAdapter.so` as plugin library and send the method to be invoked as `add` to it.
- Updated the calculator.json with other options available for out-of-process execution