### PR TITLE
RDK-41702:[RDKE] reduce the memory contribution by thunder-rs example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,5 @@
 members = [
   "sdk",
   "host",
-  "examples/calculator",
-  "examples/hello_world",
   "examples/stateful_async"
 ]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,2 +1,2 @@
 [workspace]
-members = [ "hello_world", "calculator", "stateful_async" ] 
+members = [ "stateful_async" ] 


### PR DESCRIPTION
Reason for change: To reduce the memory contribution by thunder-rs examples to Flex2.0 Rootfs
Risks: Low
Signed-off-by: Amali Bose amabose@synamedia.com
